### PR TITLE
Clarify new Date(str) alternative

### DIFF
--- a/src/rules/messages.js
+++ b/src/rules/messages.js
@@ -7,5 +7,5 @@ module.exports = {
   deprecatedTZ: (issue) =>
     `Deprecated ${issue}, use date-fns-tz to do timezone manipulation work instead.`,
   deprecatedNewDate: (issue) =>
-    `Deprecated ${issue}, this can easily cause timezone issues.`,
+    `Deprecated ${issue}, this can easily cause timezone issues. Use date-fns/parseISO instead.`,
 };

--- a/src/rules/no-new-date-with-args.js
+++ b/src/rules/no-new-date-with-args.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     docs: {
       description:
-        'Deprecate new Date(args) expression, this can easily cause timezone issues.',
+        'Deprecate new Date(args) expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
     },
     type: 'problem',
   },

--- a/src/rules/no-new-date-with-string-args.js
+++ b/src/rules/no-new-date-with-string-args.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     docs: {
       description:
-        'Deprecate new Date("some string") expression, this can easily cause timezone issues.',
+        'Deprecate new Date("some string") expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
     },
     type: 'problem',
   },

--- a/test/no-new-date-with-args.test.js
+++ b/test/no-new-date-with-args.test.js
@@ -23,7 +23,7 @@ ruleTester.run('no-new-date-with-args', rules['no-new-date-with-args'], {
       errors: [
         {
           message:
-            'Deprecated new Date(args) expression, this can easily cause timezone issues.',
+            'Deprecated new Date(args) expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
         },
       ],
     },
@@ -32,7 +32,7 @@ ruleTester.run('no-new-date-with-args', rules['no-new-date-with-args'], {
       errors: [
         {
           message:
-            'Deprecated new Date(args) expression, this can easily cause timezone issues.',
+            'Deprecated new Date(args) expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
         },
       ],
     },
@@ -41,7 +41,7 @@ ruleTester.run('no-new-date-with-args', rules['no-new-date-with-args'], {
       errors: [
         {
           message:
-            'Deprecated new Date(args) expression, this can easily cause timezone issues.',
+            'Deprecated new Date(args) expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
         },
       ],
     },

--- a/test/no-new-date-with-string-args.test.js
+++ b/test/no-new-date-with-string-args.test.js
@@ -32,7 +32,7 @@ ruleTester.run(
         errors: [
           {
             message:
-              'Deprecated new Date("some string") expression, this can easily cause timezone issues.',
+              'Deprecated new Date("some string") expression, this can easily cause timezone issues. Use date-fns/parseISO instead.',
           },
         ],
       },


### PR DESCRIPTION
We should clarify the suggested alternative to new Date(str), in line with the proposed production standard.

The `parse` function is also an option if the string isn't in ISO format, but in the majority of use cases `parseISO` should fit. Providing two options is likely more confusing so biasing on the more opinionated side.
